### PR TITLE
fix(build): path to example pdf in embed file guide

### DIFF
--- a/docs/guides/mkdocs/mkdocs-embed-pdf.md
+++ b/docs/guides/mkdocs/mkdocs-embed-pdf.md
@@ -34,9 +34,9 @@ docs
 ```
 
 ```markdown
-<embed src="../../files/example.pdf" type="application/pdf" width="100%" height=800>
+<embed src="../../../files/example.pdf" type="application/pdf" width="100%" height=800>
 ```
 
 The PDF is from [https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf](https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf)
 
-<embed src="../../files/example.pdf" type="application/pdf" width="100%" height=800>
+<embed src="../../../files/example.pdf" type="application/pdf" width="100%" height=800>


### PR DESCRIPTION
# rwaight.github.io - Pull Request

## Why are you opening this PR?

fix the path to `example.pdf` in the embed file guide

## Related issues
<!--- Are there any related issues? --->
<!--- Please include the URL to the related issue(s). If the PR fixes a bug or resolves a feature request, be sure to link to that issue. --->
**Issue URL(s)**: 
