### PR TITLE
build: allow git committers plugin to be disabled locally

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -214,6 +214,9 @@ plugins:
         - index.md
         - blog/index.md
         - test-*.md
+      # allow the plugin to be disabled locally by setting the environment variable 'ENABLE_GIT_COMMITTERS' to 'false'
+      # use 'ENABLE_GIT_COMMITTERS=false mkdocs serve' to run mkdocs and disable the plugin locally
+      enabled: !ENV [ENABLE_GIT_COMMITTERS, true]   # defaults to true
   - meta:
       # https://squidfunk.github.io/mkdocs-material/plugins/meta/
       # settings: https://squidfunk.github.io/mkdocs-material/plugins/meta/#general


### PR DESCRIPTION
# GitHub pages site - Pull Request

## Why are you opening this PR?

Allow the `mkdocs-git-committers-plugin-2` plugin to be disabled when running MkDocs locally.

Use the following command to disable the plugin:
```shell
ENABLE_GIT_COMMITTERS=false mkdocs serve
```

## Related issues
<!--- Are there any related issues? --->
<!--- Please include the URL to the related issue(s). If the PR fixes a bug or resolves a feature request, be sure to link to that issue. --->
**Issue URL(s)**: 
