### PR TITLE
docs: add excerpt option for blog posts

### DIFF
--- a/docs/blog/posts/2019/bash-timezone-checks.md
+++ b/docs/blog/posts/2019/bash-timezone-checks.md
@@ -16,6 +16,11 @@ tags:
 
 If you try to build an over-complicated scheduler using `bash`, you may run into issues when it comes to Daylight Saving Time.  While it is a good idea to use Coordinated Universal Time (UTC), you might want to make sure you do not run into issues.  The examples will use the `date` with the `+"%H:%M"` format.
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 Using `date` with the `-u` option:
 ```bash
 $ date -u +"%H:%M"

--- a/docs/blog/posts/2023/git-describe-tags.md
+++ b/docs/blog/posts/2023/git-describe-tags.md
@@ -18,6 +18,11 @@ categories:
 
 Use `git describe --tags` to get the tags.
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 ### Using git describe
 
 <!--- switch from the details element to MkDocs admonitions --->

--- a/docs/blog/posts/2023/git-revert-commits.md
+++ b/docs/blog/posts/2023/git-revert-commits.md
@@ -20,6 +20,11 @@ Examples to revert changes in a repo, primarily using `git revert`.  These examp
 - https://stackoverflow.com/questions/3293531/how-to-permanently-remove-few-commits-from-remote-branch
 - https://christoph.ruegg.name/blog/git-howto-revert-a-commit-already-pushed-to-a-remote-reposit
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 ## Revert an already pushed commit
 
 **Important**: Make sure you specify which branches on `git push -f` or you might inadvertently modify other branches![*]

--- a/docs/blog/posts/2024/dark-mode-in-chromium-browsers.md
+++ b/docs/blog/posts/2024/dark-mode-in-chromium-browsers.md
@@ -28,6 +28,11 @@ If you use a chromium browser and love dark mode, then keep reading.
 
 ## Setting dark mode for everything
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 If you love dark mode for everything... you can enable **Auto Dark Mode for Web Contents** by setting `chrome://flags/#enable-force-dark`. If that does not work, then go to `chrome://flags/` and search for **Dark Mode**.
 
 Referenced from [How do I set Google Calendar to Dark Mode?](https://support.google.com/calendar/thread/9762643?hl=en&msgid=37038653)

--- a/docs/blog/posts/2024/enable-debug-for-verbose-github-actions.md
+++ b/docs/blog/posts/2024/enable-debug-for-verbose-github-actions.md
@@ -24,6 +24,11 @@ tags:
 
 If you are using composite actions that support their own **verbose mode**, you may find you only want to enable **verbose mode** when the GitHub runner is in **debug mode**.  The variable we need to know is `runner.debug`, which is also stored as `RUNNER_DEBUG`.
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 ### Understanding when variables are available
 
 In a GitHub workflow there are three different situations where different environmental variables are available, GitHub calls this "context".  There is `workflow` context, `job` context, and `step` context.  The `runner.*` and `RUNNER_*` variables are available in the `STEP` environmental context, **but not** in the `workflow` or `job` environmental context.

--- a/docs/blog/posts/2024/encouraging-git-hygiene-with-commitlint.md
+++ b/docs/blog/posts/2024/encouraging-git-hygiene-with-commitlint.md
@@ -23,6 +23,11 @@ links:
 
 I added a [GitHub Action that uses commitlint](https://github.com/rwaight/actions/blob/v0.2/.github/workflows/check-commits.yml) to my [GitHub Actions Monorepo](https://github.com/rwaight/actions).  The GitHub Action is based off of [**commitlint**](https://commitlint.js.org/) ([commitlint GitHub](https://github.com/conventional-changelog/commitlint)) and has been added in an effort to encourage (enforce?) good **git hygiene**.  _Note_: The original [`actions-ci` workflow](https://github.com/rwaight/actions/blob/v0.1.12/.github/workflows/actions-ci.yml) was added in the [`v0.1.12` release](https://github.com/rwaight/actions/releases/tag/v0.1.12).
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 
 The workflow originated from [the _CI setup_ **GitHub Actions** section](https://commitlint.js.org/guides/ci-setup.html#github-actions) of the [commitlint guides](https://commitlint.js.org/guides/ci-setup.html).  The example workflow needed to be updated in order to run, but it should be working now.
 

--- a/docs/blog/posts/2024/reset-a-cisco-catalyst-switch.md
+++ b/docs/blog/posts/2024/reset-a-cisco-catalyst-switch.md
@@ -36,6 +36,11 @@ delete flash:vlan.dat
 reload
 ```
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 If there are other files that need to be deleted, run the following **before** issuing the `reload` command:
 ```shell
 show file information flash:?

--- a/docs/blog/posts/2025/agile-hierarchy.md
+++ b/docs/blog/posts/2025/agile-hierarchy.md
@@ -29,6 +29,11 @@ links:
 
 In distributed teams, having a shared understanding of Agile terminology is essential to working effectively. This post explains the hierarchy of Agile work items and how they fit together to support clarity, alignment, and execution.
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 ## 🧩 Work Item Hierarchy Overview
 
 ```mermaid

--- a/docs/blog/posts/2025/agile-story-vs-task.md
+++ b/docs/blog/posts/2025/agile-story-vs-task.md
@@ -47,6 +47,11 @@ links:
 
 In Agile frameworks like Scrumban, understanding the distinction between a task and a story is crucial for effective project management. A user story is typically functionality that will be visible to end users and captures requirements and acceptance criteria from the user's perspective. Developing a user story usually involves multiple roles such as a programmer, tester, user interface designer, or analyst, indicating that it contains multiple types of work. [03][03]
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 On the other hand, a task is a unit of work that is generally worked on by one person and is restricted to a single type of work. Tasks are implementation activities designed to prove that the requirements and acceptance criteria of user stories have been met. They are often technical in nature, such as implementing a class, setting up a virtual machine, writing a script, or conducting UI testing. [02][02]
 
 In the context of Jira, a popular tool for Agile project management, a Story is a more specific version of a Task. Both are work requests, but a Story was created to help people tracking User Stories in Jira. Tasks in Jira are considered "units" of work and are often used for activities that are not testable, whereas stories are for functionalities that can be tested and potentially shipped. [04][04]

--- a/docs/blog/posts/2025/containers-docker-multi-stage-builds.md
+++ b/docs/blog/posts/2025/containers-docker-multi-stage-builds.md
@@ -34,6 +34,11 @@ I wanted to find out how to use multi-stage builds when building containers with
 
 Docker supports [multi-stage builds](https://docs.docker.com/build/building/multi-stage/), which means a [stage can be created](https://docs.docker.com/build/building/multi-stage/#name-your-build-stages) and then a [previous stage can be used as a new stage](https://docs.docker.com/build/building/multi-stage/#use-a-previous-stage-as-a-new-stage)
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 ## Resources
 
 - [Docker Docs: Multi-stage builds](https://docs.docker.com/build/building/multi-stage/)

--- a/docs/blog/posts/2025/containers-publishing-to-artifact-registries.md
+++ b/docs/blog/posts/2025/containers-publishing-to-artifact-registries.md
@@ -38,6 +38,11 @@ I wanted to find out how to [publish container images to both][01] the GitHub Co
 $ docker images
 ```
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 ## GitHub Container Registry
 
 The `ghcr.io` domain name is used for GitHub's built-in container registry, known as [GitHub Container Registry (GHCR)][11].

--- a/docs/blog/posts/2025/defining-the-wiki-doc-types.md
+++ b/docs/blog/posts/2025/defining-the-wiki-doc-types.md
@@ -38,6 +38,11 @@ As I continue to build out this wiki, I thought it would be helpful to provide a
 
 Reference docs explain what a tool is and why it's used, while guides provide step-by-step instructions for completing specific tasks once you're ready to take action.
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 <!--- 
 - **Services and Overview Docs** provide high-level information and context about an application or tool. They explain what the tool is, its purpose, and how it fits into the broader system or workflow. These docs are ideal for users who are trying to understand or learn about the tool at a conceptual level.
 - **Guides** focus on action-oriented, step-by-step instructions to accomplish specific tasks. They assume the reader already understands the basics of the tool from the overview docs and is ready to perform a particular operation or workflow.

--- a/docs/blog/posts/2025/distributed-team-using-scrumban.md
+++ b/docs/blog/posts/2025/distributed-team-using-scrumban.md
@@ -30,6 +30,11 @@ Being flexible and efficient can make working in a distributed team a great expe
 
 Scrumban combines two leading Agile methodologies—Scrum and Kanban—into a single process for getting work done. But what is scrumban? And why should you consider its unique approach?
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 These are notes based on the following resources:
 
 - [Understanding the 4 Agile ceremonies][10]

--- a/docs/blog/posts/2025/distributed-team-work-tracking.md
+++ b/docs/blog/posts/2025/distributed-team-work-tracking.md
@@ -36,6 +36,11 @@ As mentioned in the [_Using Scrumban in a distributed team_](./distributed-team-
 There _should be_ a formally established process to follow in order to help everyone understand expectations. 
 In this scenario, we can find out how we can use [GitHub issues to plan and track work][01] which can be helpful given the [recent changes the GitHub team is making to issues and projects][02].
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 <!--- 
 References for later:
 

--- a/docs/blog/posts/2025/github-auth-to-cli-conditionally.md
+++ b/docs/blog/posts/2025/github-auth-to-cli-conditionally.md
@@ -1,0 +1,93 @@
+---
+# page configuration
+title: Conditionally authenticate to the GitHub CLI
+description: >
+  Using GitHub Actions to authenticate to the GitHub CLI as either a user or a bot
+#icon: octicons/repo-template-24
+status: new
+# page metadata
+draft: true
+date:
+  created: 2025-08-21
+  updated: 2025-09-18
+authors:
+  - rwaight
+categories:
+  - GitHub
+slug: github-auth-to-cli-conditionally
+tags:
+  - GitHub
+links:
+  # All relative links are resolved from the docs directory.
+  - guides/github/overview.md
+  - guides/github/github-use-gh-cli.md
+---
+
+<!---  # Conditionally authenticate to the GitHub CLI  --->
+<!---  do not put an actual 'heading 1' if it is the same as the title  --->
+
+Using GitHub Actions to authenticate to the GitHub CLI as either a user or a bot.
+
+### References
+
+- [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token)
+    - [Configure git CLI for an app's bot user](https://github.com/actions/create-github-app-token#configure-git-cli-for-an-apps-bot-user)
+- [issues in `actions/create-github-app-token`](https://github.com/actions/create-github-app-token/issues)
+    - [`#148` Return the GitHub App user id](https://github.com/actions/create-github-app-token/issues/148)
+- [PRs in `actions/create-github-app-token`](https://github.com/actions/create-github-app-token/pulls)
+    - [`#105` feat(outputs): app-slug and installation-id](https://github.com/actions/create-github-app-token/pull/105)
+    - [`#145` docs(README): fix committer string example and add git config example](https://github.com/actions/create-github-app-token/pull/145)
+- [Setup Git Credential Helper](https://github.com/jongio/gh-setup-git-credential-helper/blob/main/gh-setup-git-credential-helper)
+
+
+### Configure git CLI for an app's bot user
+
+<!--- https://github.com/actions/create-github-app-token#configure-git-cli-for-an-apps-bot-user --->
+
+```yaml
+on: [pull_request]
+
+jobs:
+  auto-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          # required
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+      # git commands like commit work using the bot user
+      - run: |
+          git add .
+          git commit -m "Auto-generated changes"
+          git push
+```
+
+> [!TIP]
+> The `<BOT USER ID>` is the numeric user ID of the app's bot user, which can be found under `https://api.github.com/users/<app-slug>%5Bbot%5D`.
+>
+> For example, we can check at `https://api.github.com/users/dependabot[bot]` to see the user ID of Dependabot is 49699333.
+>
+> Alternatively, you can use the [octokit/request-action](https://github.com/octokit/request-action) to get the ID.
+
+
+
+## Example section
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod
+nulla. Curabitur feugiat, tortor non consequat finibus, justo purus auctor
+massa, nec semper lorem quam in massa.
+
+<!--  example comment here  -->
+<!--- another example comment --->
+
+<!---  ...  --->

--- a/docs/blog/posts/2025/github-auth-to-cli-conditionally.md
+++ b/docs/blog/posts/2025/github-auth-to-cli-conditionally.md
@@ -28,6 +28,11 @@ links:
 
 Using GitHub Actions to authenticate to the GitHub CLI as either a user or a bot.
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 ### References
 
 - [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token)

--- a/docs/blog/posts/2025/github-reusable-workflow-references.md
+++ b/docs/blog/posts/2025/github-reusable-workflow-references.md
@@ -32,6 +32,11 @@ Enabling a GitHub [composite action](https://docs.github.com/en/actions/creating
 This **can be done** with [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows), but 
 not yet composite actions: [github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally](https://github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally/)
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 ### The problem
 
 When running a [composite action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action) 

--- a/docs/blog/posts/2025/github-workflows-matrix-strategy.md
+++ b/docs/blog/posts/2025/github-workflows-matrix-strategy.md
@@ -23,7 +23,7 @@ links:
   - resources/index.md
 ---
 
-<!---  # Blog post template  --->
+<!---  # Using GitHub Matrix Strategy in Workflows  --->
 <!---  do not put an actual 'heading 1' if it is the same as the title  --->
 
 This is a template file for blog posts in MkDocs.  In order to keep it simple to create new posts, the template file should have the following:

--- a/docs/blog/posts/2025/github-workflows-matrix-strategy.md
+++ b/docs/blog/posts/2025/github-workflows-matrix-strategy.md
@@ -26,7 +26,13 @@ links:
 <!---  # Using GitHub Matrix Strategy in Workflows  --->
 <!---  do not put an actual 'heading 1' if it is the same as the title  --->
 
-This is a template file for blog posts in MkDocs.  In order to keep it simple to create new posts, the template file should have the following:
+This is a template file for blog posts in MkDocs.  
+
+<!-- more -->
+
+<!--- https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
+In order to keep it simple to create new posts, the template file should have the following:
 
 ### References
 

--- a/docs/blog/posts/2025/high-doc-low-meeting-work-culture.md
+++ b/docs/blog/posts/2025/high-doc-low-meeting-work-culture.md
@@ -1,0 +1,102 @@
+---
+#title: The Perks of a High-Documentation, Low-Meeting Work Culture (Summary)
+title: Summarizing the perks of a high-documentation, low-meeting work culture
+description: >
+  This page summarizes key points from a Tremendous article (Oct 9, 2024) 
+  about designing a high-documentation, low-meeting culture and why it 
+  improves productivity, clarity, and scalability.
+draft: true
+date:
+  created: 2024-10-09
+  updated: 2025-09-29
+tags:
+  - work-culture
+  - documentation
+  - meetings
+  - async
+# authors:
+#   - Kate Monica
+# source:
+#   - Tremendous blog (Kate Monica)
+#   - url: https://www.tremendous.com/blog/the-perks-of-a-high-documentation-low-meeting-work-culture
+links:
+  - https://www.tremendous.com/blog/the-perks-of-a-high-documentation-low-meeting-work-culture
+---
+
+<!--- # The Perks of a High-Documentation, Low-Meeting Work Culture — Summary --->
+
+*This page summarizes key points from a Tremendous article (Oct 9, 2024) about designing a high-documentation, low-meeting culture and why it improves productivity, clarity, and scalability.*
+**Source:** [Tremendous — "The Perks of a High-Documentation, Low-Meeting Work Culture."][01] *(5-min read, Oct 9, 2024).*
+
+
+## TL;DR
+
+- Default to writing over meeting: decisions, proposals, and updates are documented where people work (e.g., docs near code, tickets, knowledge base).
+- Meetings become **rare and purposeful** (e.g., high-bandwidth debates or sensitive topics) rather than status updates.
+- Benefits: more focus time, transparent decision trails, easier onboarding, and scalable knowledge sharing.
+
+
+## Why it matters
+
+- **Focus & flow:** Fewer interruptions → deeper work and better outcomes.
+- **Transparent memory:** Written records reduce knowledge silos and “who do I ask?” delays.
+- **Scalability:** Teams grow without proportional meeting overhead.
+- **Onboarding & handoffs:** New folks learn faster via docs linked to the work itself.
+
+
+## Core practices (as described in the article)
+
+1. **Document by default.** Treat writing as part of the work, not an afterthought.
+2. **Keep docs close to the work.** Store design notes, runbooks, and decisions alongside code/issues where possible.
+3. **Prefer async first.** Use Slack/issue threads/docs for questions and proposals; escalate to meetings only when needed.
+4. **Low process, not no process.** Lightweight guardrails to move fast without red tape.
+5. **Make meetings count.** Use them for high-bandwidth collaboration (heated topics, complex tradeoffs), with pre-reads and clear outcomes.
+
+
+## Common pitfalls & how to avoid them
+
+- **Stale documentation:** Assign owners; add review cadences; timestamp decisions.
+- **Over-writing without structure:** Provide templates for RFCs, ADRs, and updates; lint for clarity.
+- **Excluding non-writers:** Offer writing coaching, examples, and pair-writing sessions.
+- **Async drift:** Define SLAs for responses and “office hours” for faster feedback windows.
+
+
+## Simple rollout plan
+
+1. **Pick a pilot area** (e.g., one team or project).
+2. **Adopt two templates** (RFC + decision/ADR). Require links in PRs/issues.
+3. **Meeting charter:** Convert status meetings to written updates; keep only decision meetings with pre-reads.
+4. **Create “docs close to code.”** Repo /docs, ADR folder, or links from tickets.
+5. **Review loop:** Weekly 15-minute “doc hygiene” pass; monthly prune/refresh.
+6. **Measure:** Track meeting hours per person, PR/issue cycle time, and onboarding time to first meaningful commit/change.
+
+
+## Signals you’re succeeding
+
+- Fewer recurring meetings; clearer agendas and decisions in the ones that remain.
+- People find answers via search, not DMs.
+- New hires contribute faster using written trails of context.
+
+
+## Short quote (for reference)
+
+> “Our low-meeting culture allows us time to do high-value tasks.” — Tremendous (article)
+
+
+## Further reading from Tremendous (related)
+
+- *How to minimize context switching at work* (Oct 9, 2024).  
+- *How to hire for a high-documentation, low-meeting work culture* (Oct 9, 2024).  
+- *A flow state makes your teams happier and more productive* (Oct 9, 2024).
+
+---
+
+### Citation
+
+This page is a summary of: [**Tremendous — “The Perks of a High-Documentation, Low-Meeting Work Culture” (Oct 9, 2024)**][01].
+
+
+<!--- ## End --->
+
+[01]: https://docs.github.com/en/issues/tracking-your-work-with-issues/configuring-issues/planning-and-tracking-work-for-your-team-or-project
+

--- a/docs/blog/posts/2025/jq-updating-json-objects.md
+++ b/docs/blog/posts/2025/jq-updating-json-objects.md
@@ -35,6 +35,11 @@ Given the following array containing directory paths:
 ]
 ```
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 Now stored as the `paths` variable:
 
 ```shell

--- a/docs/blog/posts/2025/markdown-inline-backtick-code-formatting.md
+++ b/docs/blog/posts/2025/markdown-inline-backtick-code-formatting.md
@@ -30,6 +30,11 @@ How to put (in markdown) an inline code block that only contains a backtick char
     - [https://stackoverflow.com/a/55587012](https://stackoverflow.com/a/55587012)
     - [https://stackoverflow.com/a/71150969](https://stackoverflow.com/a/71150969)
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 <!--  example comment here  -->
 <!--- another example comment --->
 

--- a/docs/blog/posts/2025/mermaid-diagram-legend.md
+++ b/docs/blog/posts/2025/mermaid-diagram-legend.md
@@ -28,6 +28,11 @@ It might be helpful to add a legend to graphs using [Mermaid](https://github.com
 Here are some examples to test workarounds for legends in a graph from [mermaid-js/mermaid#2110](https://github.com/mermaid-js/mermaid/issues/2110)
 
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 ### Legends in a Graph Example 1
 
 <!--- source https://github.com/mermaid-js/mermaid/issues/2110#issuecomment-1057895108 --->

--- a/docs/blog/posts/2025/multi-line-strings-in-YAML.md
+++ b/docs/blog/posts/2025/multi-line-strings-in-YAML.md
@@ -34,6 +34,11 @@ There are <s>5</s> *<s>6</s>* ***NINE*** (or 63\*, depending how you count) diff
 
 ### TL;DR
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 - Use `>` if you want to break a string up for readability but for it to still be treated as a single-line string: interior line breaks will be stripped out, there will only be one line break at the end:
 
 ```yml

--- a/docs/blog/posts/2025/personal-time-tracking.md
+++ b/docs/blog/posts/2025/personal-time-tracking.md
@@ -40,6 +40,11 @@ The actual query would be:
 from:@SlackUsername before:2025-02-08 after:2025-02-02
 ```
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 ### Review GitHub commits during the week
 
 [GitHub Docs - Searching commits](https://docs.github.com/en/search-github/searching-on-github/searching-commits)

--- a/docs/blog/posts/2025/regex-for-release-notes.md
+++ b/docs/blog/posts/2025/regex-for-release-notes.md
@@ -36,6 +36,11 @@ by (@.*) in https://github.com/rwaight/rwaight.github.io/pull/(\d+)
 ![regex-release-notes-pr-entries-vscode](images/regex-release-notes-pr-entries-vscode.png)
 
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 ### Replace the commit message type
 
 **Find**:

--- a/docs/blog/posts/2025/restructuring-gh-pages-site.md
+++ b/docs/blog/posts/2025/restructuring-gh-pages-site.md
@@ -23,7 +23,13 @@ tags:
 <!---  # Blog post template  --->
 <!---  do not put an actual 'heading 1' if it is the same as the title  --->
 
-This is a template file for blog posts in MkDocs.  In order to keep it simple to create new posts, the template file should have the following:
+This is a template file for blog posts in MkDocs.  
+
+<!-- more -->
+
+<!--- https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
+In order to keep it simple to create new posts, the template file should have the following:
 
 <!--- 
 - The page **front-matter** section, which includes:

--- a/docs/blog/posts/2025/win10-bootable-usb-from-mac.md
+++ b/docs/blog/posts/2025/win10-bootable-usb-from-mac.md
@@ -35,6 +35,11 @@ Resource: https://www.freecodecamp.org/news/how-make-a-windows-10-usb-using-your
 brew install wimlib
 ```
 
+<!-- more -->
+
+<!--- keep the 'more' entry above in place, the text above will become an 'excerpt' on the blog site
+https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
 ```shell
 win_usb=/dev/disk5
 win_iso=~/Downloads/Win10_22H2_English_x64v1.iso

--- a/docs/blog/posts/blog-post-template.md
+++ b/docs/blog/posts/blog-post-template.md
@@ -63,6 +63,7 @@ When creating a new blog post, determine the following [page metadata](https://s
 - the post [`categories`](https://squidfunk.github.io/mkdocs-material/plugins/blog/#meta.categories)
 - the post [`slug`](https://squidfunk.github.io/mkdocs-material/plugins/blog/#meta.slug)
 - the post [`tags`](https://squidfunk.github.io/mkdocs-material/plugins/tags/#meta.tags)
+- the post [`links`](https://squidfunk.github.io/mkdocs-material/plugins/blog/#meta.links)
 
 
 ## Putting it all together
@@ -92,6 +93,10 @@ slug: blog-post-template
 tags:
   - MkDocs
   - Template
+links:
+  # All relative links are resolved from the docs directory.
+  - references/index.md
+  - resources/index.md
 ---
 ````
 

--- a/docs/blog/posts/blog-post-template.md
+++ b/docs/blog/posts/blog-post-template.md
@@ -28,7 +28,13 @@ links:
 <!---  # Blog post template  --->
 <!---  do not put an actual 'heading 1' if it is the same as the title  --->
 
-This is a template file for blog posts in MkDocs.  In order to keep it simple to create new posts, the template file should have the following:
+This is a template file for blog posts in MkDocs.  
+
+<!-- more -->
+
+<!--- https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt --->
+
+In order to keep it simple to create new posts, the template file should have the following:
 
 <!--- 
 - The page **front-matter** section, which includes:
@@ -65,6 +71,10 @@ When creating a new blog post, determine the following [page metadata](https://s
 - the post [`tags`](https://squidfunk.github.io/mkdocs-material/plugins/tags/#meta.tags)
 - the post [`links`](https://squidfunk.github.io/mkdocs-material/plugins/blog/#meta.links)
 
+
+### Excerpt
+
+An excerpt can be created by adding a `<!-- more -->` separator after the first few paragraphs of a post.
 
 ## Putting it all together
 


### PR DESCRIPTION
# GitHub pages site - Pull Request

## Why are you opening this PR?

Update the blog posts so the first few sentences become an 'excerpt' on the blog site
- see https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt

## Related issues
<!--- Are there any related issues? --->
<!--- Please include the URL to the related issue(s). If the PR fixes a bug or resolves a feature request, be sure to link to that issue. --->
**Issue URL(s)**: 
