### PR TITLE
chore: add CLAUDE.md with git safety rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# Claude Code Instructions — rwaight/rwaight.github.io
+
+This file is automatically loaded by Claude Code when working in this repository.
+
+---
+
+## Git Branch Policy
+
+**NEVER commit directly to `main`.** This is a hard rule with no exceptions, including for agents operating autonomously.
+
+Required workflow for all changes:
+1. Verify you are NOT on main: `git branch --show-current`
+2. If on main, create a branch first: `git checkout -b <type>/<description>`
+3. Make commits on the feature branch
+4. Push: `git push -u origin <branch-name>`
+5. Open a PR: `gh pr create --base main`
+
+Never run `git push origin main` or `git push origin HEAD:main`.
+
+---
+
+## Commit Message Convention
+
+Commits follow **Conventional Commits** format: `<type>(<optional-scope>): <description>`
+
+Common types: `feat`, `fix`, `docs`, `chore`, `ci`, `refactor`


### PR DESCRIPTION
## Why are you opening this PR?
Adds a minimal CLAUDE.md with a hard rule prohibiting Claude Code agents from committing directly to main, along with a required PR workflow checklist.

## Related issues
**Issue URL(s)**: N/A