### PR TITLE
build: publish a PyPI-based public MkDocs Material image

### DIFF
--- a/.github/workflows/build-and-push-mkdocs-container.yml
+++ b/.github/workflows/build-and-push-mkdocs-container.yml
@@ -145,11 +145,12 @@ jobs:
             type=ref,event=branch,prefix=branch-,enable=${{ steps.flavor.outputs.ENABLE_BRANCH_TAG == 'true' }}
             type=sha,prefix=sha-,format=short
           # https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
+          # Leave org.opencontainers.image.revision to metadata-action (git SHA).
+          # Build version is io.github.rwaight.build.version.
           labels: |
             org.opencontainers.image.title=mkdocs-material
             org.opencontainers.image.description=Material for MkDocs with site plugins
             org.opencontainers.image.documentation=https://github.com/${{ github.repository }}/blob/main/container/README.md
-            org.opencontainers.image.revision=${{ steps.get-version.outputs.build-version }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.url=https://github.com/${{ github.repository }}/tree/main/container
             org.opencontainers.image.version=${{ steps.get-version.outputs.build-version }}
@@ -211,10 +212,15 @@ jobs:
           done <<< "${{ steps.metadata.outputs.tags }}"
           docker run --rm mkdocs-material:ci-smoke --version
           # Entrypoint is mkdocs; --version reports the MkDocs CLI, not Material.
-          # Override entrypoint to confirm the requirements.txt pin is in the image.
-          docker run --rm --entrypoint pip mkdocs-material:ci-smoke show mkdocs-material
-          docker run --rm --entrypoint pip mkdocs-material:ci-smoke show mkdocs-material \
-            | grep -F "Version: ${MATERIAL_VERSION}"
+          docker run --rm --entrypoint pip mkdocs-material:ci-smoke check
+          while IFS= read -r line || [[ -n "${line}" ]]; do
+            [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+            [[ -z "${line// }" ]] && continue
+            pkg="${line%%==*}"
+            ver="${line#*==}"
+            docker run --rm --entrypoint pip mkdocs-material:ci-smoke show "${pkg}" \
+              | grep -F "Version: ${ver}"
+          done < requirements.txt
 
       - name: Push the smoke-tested image
         if: github.repository == 'rwaight/rwaight.github.io' && github.actor != 'dependabot[bot]'

--- a/.github/workflows/build-and-push-mkdocs-container.yml
+++ b/.github/workflows/build-and-push-mkdocs-container.yml
@@ -1,336 +1,165 @@
-# from https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+# Publish the public MkDocs Material image to GHCR.
 name: Build MkDocs container image
 run-name: Build and publish MkDocs container image
 
-# Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
     tags:
-      - 'v[0-9][0-9]?.[0-9][0-9]?.[0-9][0-9]?'
-      # the major.minor and major tags are evaluated below
-      #- 'v[0-9][0-9]?.[0-9][0-9]?'
-      #- 'v[0-9][0-9]?'
-      #
-      # the 'v[0-9].[0-9].[0-9]' filter pattern will need to be updated to allow double digits, using either: 
-      #    specify 2 digits with a second range followed by `?`:
-      #        'v[0-9][0-9]?.[0-9][0-9]?.[0-9][0-9]?'     
-      #    or keep the single digit, but match one or more with `+`:
-      #        'v[0-9]+.[0-9]+.[0-9]+'
-      # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-  # release:
-  #   types: [published]
-  # do not keep 'workflow_dispatch' here long term
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches-ignore:
+      - main
+      - gh-pages
+    paths:
+      - 'container/**'
+      - '.github/workflows/build-and-push-mkdocs-container.yml'
   workflow_dispatch:
 
-# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
   build-container-image:
-    name: Build and push ${{ matrix.name }} image
+    name: Build and push mkdocs-material image
     runs-on: ubuntu-latest
-    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
       packages: write
-      attestations: write
-      # https://github.com/actions/deploy-pages/issues/28#issuecomment-1087299632
-      id-token: write
-      # 
-    strategy:
-      fail-fast: false
-      matrix:
-        container: [mkdocs-material]
-        registry: [ghcr.io]
-          # not all containers will be pushed to GCP Artifact Registry
-          #registry: [ghcr.io,gcp]
-        # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-expanding-configurations
-        # use 'include' to specify additional variables
-        include:
-          - container: mkdocs-material
-            name: mkdocs-material
-            description: "Material for MkDocs: Documentation that simply works"
-            dir: container
-            #go-version: 1.17.x
-            #test: "-e DOCKER_TEST_ONLY=true"
-            version_source: 9.6.19
-    # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
     env:
-      REGISTRY: ${{ matrix.registry }}
-      IS_GHCR: ${{ matrix.registry == 'ghcr.io' && 'true' || 'false' }}
-      # GCP Artifact Registry
-      IS_GCP_AR: ${{ matrix.registry == 'gcp' && 'true' || 'false' }}
-      GCP_AR_REGION: us-central1
-      GCP_AR_PROJECT: my-gcp-project
-      GCP_AR_REPO: my-artifact-repo
-      #IMAGE_NAME: ${{ github.repository }}
-      IMAGE_NAME: ${{ github.repository }}/${{ matrix.name }}
-      IS_REF_TAG: ${{ github.ref_type == 'tag' && 'true' || 'false' }}
-      # MkDocs Material
-      IS_MKDOCS_MATERIAL: ${{ matrix.container == 'mkdocs-material' && 'true' || 'false' }}
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}/mkdocs-material
+      MATERIAL_VERSION: '9.7.7'
     defaults:
       run:
-        # set the the runners 'working-directory' to '${{ matrix.dir }}'
-        # https://docs.github.com/en/actions/using-jobs/setting-default-values-for-jobs#setting-default-shell-and-working-directory
-        working-directory: ./${{ matrix.dir }}
+        working-directory: ./container
     steps:
 
       - name: Checkout repository
-        # Verified creator: https://github.com/marketplace/actions/checkout
-        # GitHub Action for checking out a repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
-          #token: ${{ secrets.GITHUB_TOKEN }}
           sparse-checkout: |
             .github
-            ${{ matrix.dir }}
+            container
         id: checkout
-
-      - name: Display structure of files in working directory
-        #if: inputs.verbose=='true' || ${{ runner.debug == '1' }}
-        run: ls -R
 
       - name: Get the build version
         id: get-version
-        uses: rwaight/actions/vars/build-version@main
+        uses: rwaight/actions/vars/build-version@v0.2.6
         with:
           checkout: false
           strategy: 'simple'
           verbose: ${{ runner.debug == '1' && 'true' || 'false' }}
 
-      - name: Print build version
-        id: print-build-version
-        if: ${{ steps.get-version.outputs.build-version }}
-        run: |
-          echo "::group::starting step 'print-build-version' "
-          echo ""
-          echo "Output from the 'get-version' step"
-          echo "    build-version: ${{ steps.get-version.outputs.build-version }} "
-          echo ""
-          echo "The output in the 'get-version' step was ${build_version} ."
-          echo ""
-          echo "completing the 'print-build-version' step. "
-          echo "::endgroup::"
-        env:
-          build_version: ${{ steps.get-version.outputs.build-version }}
+      - name: Set repository name
+        id: set-repository-name
+        run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
         shell: bash
 
-      - name: Setup Go environment
-        if: ${{ matrix.go-version }}
-        # Verified creator: https://github.com/marketplace/actions/setup-go-environment
-        # Set up your GitHub Actions workflow with a specific version of Go
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
-        with:
-          go-version: ${{ matrix.go-version }}
-        id: setup-go
-
-      - name: Install QEMU static binaries
-        # Verified creator: https://github.com/marketplace/actions/docker-setup-qemu
-        # GitHub Action to install QEMU static binaries
-        uses: docker/setup-qemu-action@v3.6.0
-        id: setup-qemu
+      - name: Set image flavor
+        id: flavor
+        shell: bash
+        run: |
+          prod=false
+          branch_tag=false
+          major_alias=false
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            prod=true
+            major="${BASH_REMATCH[1]}"
+            if (( major > 0 )); then
+              major_alias=true
+            fi
+          elif [[ "${GITHUB_REF_TYPE}" == "branch" && "${GITHUB_REF_NAME}" != "main" && "${GITHUB_REF_NAME}" != "gh-pages" ]]; then
+            branch_tag=true
+          fi
+          echo "IS_PRODUCTION=${prod}" >> "$GITHUB_OUTPUT"
+          echo "ENABLE_BRANCH_TAG=${branch_tag}" >> "$GITHUB_OUTPUT"
+          echo "ENABLE_MAJOR_ALIAS=${major_alias}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Docker Buildx
-        # Verified creator: https://github.com/marketplace/actions/docker-setup-buildx
-        # GitHub Action to set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         id: setup-buildx
 
-      - name: Set variables to use to build the container
-        id: set-container-variables
-        run: |
-          echo "setting custom variables used to build the container"
-          ## Lowercase repository name
-          echo "REPOSITORY_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
-          ## create a tag with either the full tag name (i.e., 'v1.2.2') 
-          ##   or the output from 'git describe' (i.e., 'v1.0-183-g806a325')
-          ##
-          ## ## possibly use '${{ github.event.release.tag_name }}' to build the container when the release is published
-          ## ## otherwise use the ref_name if (github.ref_type == 'tag')
-          echo "this job is not complete yet"
-        shell: bash
-
       - name: Login to the GitHub Container Registry
-        # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
-        if: matrix.registry == 'ghcr.io'
-        # Verified creator: https://github.com/marketplace/actions/docker-login
-        # GitHub Action to login against a Docker registry
+        if: github.repository == 'rwaight/rwaight.github.io' && github.actor != 'dependabot[bot]'
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
-          #username: ${{ github.actor }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
         id: docker-login-ghcr
 
-      - name: Login to the GCP Artifact Registry
-        if: matrix.registry == 'gcp'
-        uses: docker/login-action@v3
-        # Verified creator: https://github.com/marketplace/actions/docker-login
-        # GitHub Action to login against a Docker registry
-        with:
-          #registry: us-central1-docker.pkg.dev
-          registry: "${{ env.GCP_AR_REGION }}-docker.pkg.dev"
-          username: _json_key
-          password: ${{ secrets.GCP_BUILD_CONTAINERS_KEY }}
-        id: docker-login-gcp-ar
-
-      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
-        # Verified creator: https://github.com/marketplace/actions/docker-metadata-action
-        # GitHub Action to extract metadata (tags, labels) from Git reference and GitHub events for Docker 
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
-          # https://github.com/docker/metadata-action#images-input
-          images: |
-            name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},enable=${{ env.IS_GHCR }}
-            name=ghcr.io/${{ env.IMAGE_NAME }},enable=${{ env.IS_GHCR }}
-            name=${{ env.IMAGE_NAME }},enable=${{ env.IS_GCP_AR }}
-            name=${{ env.GCP_AR_REGION }}-docker.pkg.dev/${{ env.GCP_AR_PROJECT }}/${{ env.GCP_AR_REPO }}/${{ env.IMAGE_NAME }},enable=${{ env.IS_GCP_AR }}
-          # https://github.com/docker/metadata-action#latest-tag
-          # https://github.com/docker/metadata-action#typesha
-          # https://github.com/docker/metadata-action#typeref
-          # https://github.com/docker/metadata-action#typesemver
+          images: ghcr.io/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,priority=100,prefix=sha-,format=short
-            type=ref,priority=600,event=branch
-            type=ref,priority=600,event=tag
-            type=ref,priority=600,event=pr
-            type=semver,priority=900,enable=${{ env.IS_REF_TAG }},pattern={{version}}
-            type=semver,priority=900,enable=${{ env.IS_REF_TAG }},pattern=v{{major}}.{{minor}}
-            type=semver,priority=900,enable=${{ env.IS_REF_TAG }},pattern=v{{major}}
+            type=raw,value=latest,enable=${{ steps.flavor.outputs.IS_PRODUCTION == 'true' }}
+            type=semver,pattern={{version}},value=${{ github.ref_name }},enable=${{ steps.flavor.outputs.IS_PRODUCTION == 'true' }}
+            type=semver,pattern=v{{major}}.{{minor}},value=${{ github.ref_name }},enable=${{ steps.flavor.outputs.IS_PRODUCTION == 'true' }}
+            type=semver,pattern=v{{major}},value=${{ github.ref_name }},enable=${{ steps.flavor.outputs.ENABLE_MAJOR_ALIAS == 'true' }}
+            type=ref,event=branch,enable=${{ steps.flavor.outputs.ENABLE_BRANCH_TAG == 'true' }}
+            type=sha,prefix=sha-,format=short
           labels: |
-            org.opencontainers.image.title=${{ matrix.name }} version ${{ matrix.version_source || 'latest' }}
-            org.opencontainers.image.description=${{ matrix.description }}
-            org.opencontainers.image.documentation=https://github.com/${{ github.repository }}/blob/main/${{ matrix.dir }}/README.md
+            org.opencontainers.image.title=mkdocs-material
+            org.opencontainers.image.description=Material for MkDocs with site plugins
+            org.opencontainers.image.documentation=https://github.com/${{ github.repository }}/blob/main/container/README.md
             org.opencontainers.image.revision=${{ steps.get-version.outputs.build-version }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.url=https://github.com/${{ github.repository }}/tree/main/${{ matrix.dir }}
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}/tree/main/container
             org.opencontainers.image.version=${{ steps.get-version.outputs.build-version }}
-            io.github.rwaight.app.name=${{ matrix.name }}
-            io.github.rwaight.app.version=${{ matrix.version_source || 'latest' }}
+            io.github.rwaight.app.name=mkdocs-material
+            io.github.rwaight.app.version=${{ env.MATERIAL_VERSION }}
             io.github.rwaight.repository=${{ env.REPOSITORY_NAME || github.repository }}
             io.github.rwaight.build.version=${{ steps.get-version.outputs.build-version }}
-          ##  io.github.rwaight.repository=${{ github.repository }}
-          ##  org.opencontainers.image.version={{version}}
-          ## https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
-          annotations: |
-            org.opencontainers.image.title=${{ matrix.name }} version ${{ matrix.version_source || 'latest' }}
-            org.opencontainers.image.description=${{ matrix.description }}
-            org.opencontainers.image.documentation=https://github.com/${{ github.repository }}/blob/main/${{ matrix.dir }}/README.md
-            org.opencontainers.image.url=https://github.com/${{ github.repository }}/tree/main/${{ matrix.dir }}
         id: metadata
 
-      - name: Print the output from the metadata step
-        id: print-metadata-info
+      - name: Print image tags
         if: steps.metadata.outcome == 'success'
         run: |
-          echo "The tags metadata is: "
+          echo "IS_PRODUCTION=${{ steps.flavor.outputs.IS_PRODUCTION }}"
+          echo "ENABLE_BRANCH_TAG=${{ steps.flavor.outputs.ENABLE_BRANCH_TAG }}"
+          echo "ENABLE_MAJOR_ALIAS=${{ steps.flavor.outputs.ENABLE_MAJOR_ALIAS }}"
+          echo "Tags:"
           echo "${{ steps.metadata.outputs.tags }}"
-          echo ""
-          echo "using a bash array"
-          tags=(${{ steps.metadata.outputs.tags }})
-          echo "tag 0:  ${tags[0]}"
-          echo "tag 1:  ${tags[1]}"
-          echo ""
-          echo "tag0=${tags[0]}" >> "$GITHUB_OUTPUT"
-          echo "tag0=${tags[0]}" >> $GITHUB_ENV
-          echo "tag1=${tags[1]}" >> "$GITHUB_OUTPUT"
-          echo "tag1=${tags[1]}" >> $GITHUB_ENV
-          echo "the 'print-metadata-info' step has now completed"
         shell: bash
 
-      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
-      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
-      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
-      - name: Load the container image
-        # Verified creator: https://github.com/marketplace/actions/build-and-push-docker-images
-        # GitHub Action to build and push Docker images with Buildx
+      - name: Build and load the container image
+        if: github.repository == 'rwaight/rwaight.github.io' && github.actor != 'dependabot[bot]'
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
-        # Skip running on forks or Dependabot since neither has access to secrets
-        if: |
-          (github.repository == 'rwaight/rwaight.github.io') &&
-          (github.actor!= 'dependabot[bot]') &&
-          (contains(github.head_ref, 'dependabot-') == false)
         with:
-          #context: .
-          context: "{{defaultContext}}:${{ matrix.dir }}"
-          build-args: |
-            VERSION_SOURCE=${{ matrix.version_source || 'latest' }}
-          tags: ${{ steps.metadata.outputs.tags }}
-          annotations: ${{ steps.metadata.outputs.annotations }}
-          # maybe switch to this # annotations: ${{ steps.metadata.outputs.labels }}
-          labels: ${{ steps.metadata.outputs.labels }}
+          context: "{{defaultContext}}:container"
           load: true
-          #platforms: linux/amd64,linux/arm64
+          push: false
           platforms: linux/amd64
-        id: load-image
-
-      - name: Test the ${{ matrix.name }} Docker image
-        id: test-image
-        if: ${{ matrix.test && steps.load-image.outcome == 'success' }}
-        run: |
-          echo "going to test the image with '${{ matrix.test }}'"
-          echo "testing tag '${{ steps.print-metadata-info.outputs.tag0 }}' "
-          docker run --rm ${{ matrix.test }} ${{ steps.print-metadata-info.outputs.tag0 }}
-          echo "testing tag '${{ steps.print-metadata-info.outputs.tag1 }}' "
-          docker run --rm ${{ matrix.test }} ${{ steps.print-metadata-info.outputs.tag1 }}
-          echo "the 'test-image' step has now completed"
-        shell: bash
-
-      - name: Build and push the ${{ matrix.name }} container image
-        # Verified creator: https://github.com/marketplace/actions/build-and-push-docker-images
-        # GitHub Action to build and push Docker images with Buildx
-        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
-        # Skip running on forks or Dependabot since neither has access to secrets
-        if: |
-          (github.repository == 'rwaight/rwaight.github.io') &&
-          (github.actor!= 'dependabot[bot]') &&
-          (contains(github.head_ref, 'dependabot-') == false)
-        with:
-          #context: .
-          context: "{{defaultContext}}:${{ matrix.dir }}"
-          build-args: |
-            VERSION_SOURCE=${{ matrix.version_source || 'latest' }}
-          tags: ${{ steps.metadata.outputs.tags }}
-          annotations: ${{ steps.metadata.outputs.annotations }}
-          # maybe switch to this # annotations: ${{ steps.metadata.outputs.labels }}
-          labels: ${{ steps.metadata.outputs.labels }}
-          push: true
-          #platforms: linux/amd64,linux/arm64
-          # do not specify platforms, otherwise multiple images will be created without tags
-          # https://github.com/docker/build-push-action/issues/894
-          platforms: linux/amd64
-          # secrets: |
-          #   GIT_AUTH_TOKEN=${{ secrets.MY_PACKAGE_MGR_TOKEN }}
           provenance: false
-        id: build-image
+          tags: |
+            mkdocs-material:ci-smoke
+            ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+        id: build
 
-      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
-      - name: Generate artifact attestation
-        # Verified creator: https://github.com/marketplace/actions/attest-build-provenance
-        # Action for generating build provenance attestations for workflow artifacts
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
-        #uses: actions/attest-build-provenance@v1.0.0
-        # Skip running on forks or Dependabot since neither has access to secrets
-        if: |
-          (github.repository == 'rwaight/rwaight.github.io') &&
-          (github.actor!= 'dependabot[bot]') &&
-          (contains(github.head_ref, 'dependabot-') == false)
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.build-image.outputs.digest }}
-          push-to-registry: true
-        id: artifact-attestation
-
-      - name: Print the output from the build-image step
-        id: print-image-info
-        if: steps.build-image.outcome == 'success'
-        run: |
-          echo "The image id is: ${{ steps.build-image.outputs.imageid }}"
-          echo "The image digest is ${{ steps.build-image.outputs.digest }}"
-          echo "The image metadata is: "
-          echo "${{ fromJSON(steps.build-image.outputs.metadata) }}"
-          echo ""
+      - name: Smoke test locally loaded image
+        if: github.repository == 'rwaight/rwaight.github.io' && github.actor != 'dependabot[bot]'
+        id: smoke
         shell: bash
+        run: |
+          SMOKE_ID="$(docker image inspect mkdocs-material:ci-smoke --format '{{.Id}}')"
+          echo "SMOKE_ID=${SMOKE_ID}" >> "$GITHUB_OUTPUT"
+          echo "Smoke-testing locally loaded image: mkdocs-material:ci-smoke (${SMOKE_ID})"
+          docker image inspect mkdocs-material:ci-smoke --format '{{.Id}} {{json .RepoTags}} {{json .Config.Labels}}'
+          while IFS= read -r tag; do
+            [[ -n "${tag}" ]] || continue
+            TAG_ID="$(docker image inspect "${tag}" --format '{{.Id}}')"
+            if [[ "${TAG_ID}" != "${SMOKE_ID}" ]]; then
+              echo "::error::Tag ${tag} is ${TAG_ID}, not the smoke-tested image ${SMOKE_ID}"
+              exit 1
+            fi
+          done <<< "${{ steps.metadata.outputs.tags }}"
+          docker run --rm mkdocs-material:ci-smoke --version
+
+      - name: Push the smoke-tested image
+        if: github.repository == 'rwaight/rwaight.github.io' && github.actor != 'dependabot[bot]'
+        shell: bash
+        run: |
+          while IFS= read -r tag; do
+            [[ -n "${tag}" ]] || continue
+            docker push "${tag}"
+          done <<< "${{ steps.metadata.outputs.tags }}"

--- a/.github/workflows/build-and-push-mkdocs-container.yml
+++ b/.github/workflows/build-and-push-mkdocs-container.yml
@@ -1,15 +1,23 @@
+# from https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
 # Publish the public MkDocs Material image to GHCR.
 name: Build MkDocs container image
 run-name: Build and publish MkDocs container image
 
+# Feature-branch pushes rebuild when the image context or this workflow changes.
+# Production publishes run on semver git tags. GitHub does not evaluate `paths`
+# for tag pushes, which is the intended behavior for a tagged production build.
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
 on:
   push:
     tags:
+      # match one or more digits in each semver component
+      # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
       - 'v[0-9]+.[0-9]+.[0-9]+'
     branches-ignore:
       - main
       - gh-pages
     paths:
+      # all image inputs live under container/ (Dockerfile, requirements, docs)
       - 'container/**'
       - '.github/workflows/build-and-push-mkdocs-container.yml'
   workflow_dispatch:
@@ -18,6 +26,7 @@ jobs:
   build-container-image:
     name: Build and push mkdocs-material image
     runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
       packages: write
@@ -27,10 +36,13 @@ jobs:
       MATERIAL_VERSION: '9.7.7'
     defaults:
       run:
+        # https://docs.github.com/en/actions/using-jobs/setting-default-values-for-jobs#setting-default-shell-and-working-directory
         working-directory: ./container
     steps:
 
       - name: Checkout repository
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
@@ -57,12 +69,15 @@ jobs:
         id: flavor
         shell: bash
         run: |
+          # Production tags: latest + semver aliases. Feature branches: branch + sha.
+          # Dispatch from main or a non-semver tag: sha only.
           prod=false
           branch_tag=false
           major_alias=false
           if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
             prod=true
             major="${BASH_REMATCH[1]}"
+            # Do not publish a moving v0 tag while the image is in the 0.x series.
             if (( major > 0 )); then
               major_alias=true
             fi
@@ -74,11 +89,16 @@ jobs:
           echo "ENABLE_MAJOR_ALIAS=${major_alias}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Docker Buildx
+        # Verified creator: https://github.com/marketplace/actions/docker-setup-buildx
+        # GitHub Action to set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         id: setup-buildx
 
       - name: Login to the GitHub Container Registry
+        # Skip forks or Dependabot since neither has access to packages write.
         if: github.repository == 'rwaight/rwaight.github.io' && github.actor != 'dependabot[bot]'
+        # Verified creator: https://github.com/marketplace/actions/docker-login
+        # GitHub Action to login against a Docker registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
@@ -86,10 +106,20 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         id: docker-login-ghcr
 
+      # Extract tags and labels with docker/metadata-action.
+      # https://github.com/docker/metadata-action#about
+      # value=${{ github.ref_name }} makes dispatch-on-tag match push-of-tag.
       - name: Extract metadata (tags, labels) for Docker
+        # Verified creator: https://github.com/marketplace/actions/docker-metadata-action
+        # GitHub Action to extract metadata (tags, labels) from Git reference and GitHub events for Docker
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
+          # https://github.com/docker/metadata-action#images-input
           images: ghcr.io/${{ env.IMAGE_NAME }}
+          # https://github.com/docker/metadata-action#latest-tag
+          # https://github.com/docker/metadata-action#typesha
+          # https://github.com/docker/metadata-action#typeref
+          # https://github.com/docker/metadata-action#typesemver
           tags: |
             type=raw,value=latest,enable=${{ steps.flavor.outputs.IS_PRODUCTION == 'true' }}
             type=semver,pattern={{version}},value=${{ github.ref_name }},enable=${{ steps.flavor.outputs.IS_PRODUCTION == 'true' }}
@@ -97,6 +127,7 @@ jobs:
             type=semver,pattern=v{{major}},value=${{ github.ref_name }},enable=${{ steps.flavor.outputs.ENABLE_MAJOR_ALIAS == 'true' }}
             type=ref,event=branch,enable=${{ steps.flavor.outputs.ENABLE_BRANCH_TAG == 'true' }}
             type=sha,prefix=sha-,format=short
+          # https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
           labels: |
             org.opencontainers.image.title=mkdocs-material
             org.opencontainers.image.description=Material for MkDocs with site plugins
@@ -121,13 +152,21 @@ jobs:
           echo "${{ steps.metadata.outputs.tags }}"
         shell: bash
 
+      # Build once, load locally, then push the same image ID after the smoke test.
+      # Never push the ci-smoke tag. Never run a second build-push-action.
+      # https://github.com/docker/build-push-action#usage
       - name: Build and load the container image
+        # Skip forks or Dependabot since neither has access to packages write.
         if: github.repository == 'rwaight/rwaight.github.io' && github.actor != 'dependabot[bot]'
+        # Verified creator: https://github.com/marketplace/actions/build-and-push-docker-images
+        # GitHub Action to build and push Docker images with Buildx
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
         with:
           context: "{{defaultContext}}:container"
           load: true
           push: false
+          # do not specify multiple platforms, otherwise multiple images will be created without tags
+          # https://github.com/docker/build-push-action/issues/894
           platforms: linux/amd64
           provenance: false
           tags: |

--- a/.github/workflows/build-and-push-mkdocs-container.yml
+++ b/.github/workflows/build-and-push-mkdocs-container.yml
@@ -33,7 +33,6 @@ jobs:
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}/mkdocs-material
-      MATERIAL_VERSION: '9.7.7'
     defaults:
       run:
         # https://docs.github.com/en/actions/using-jobs/setting-default-values-for-jobs#setting-default-shell-and-working-directory
@@ -65,12 +64,26 @@ jobs:
         run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
         shell: bash
 
+      - name: Read Material version
+        id: material-version
+        shell: bash
+        run: |
+          # Single source of truth: container/requirements.txt (not a workflow env pin).
+          version="$(sed -n 's/^mkdocs-material==//p' requirements.txt)"
+          if [[ -z "${version}" ]]; then
+            echo "::error::mkdocs-material pin not found in container/requirements.txt"
+            exit 1
+          fi
+          echo "MATERIAL_VERSION=${version}" >> "$GITHUB_ENV"
+          echo "MATERIAL_VERSION=${version}" >> "$GITHUB_OUTPUT"
+
       - name: Set image flavor
         id: flavor
         shell: bash
         run: |
-          # Production tags: latest + semver aliases. Feature branches: branch + sha.
+          # Production tags: latest + semver aliases. Feature branches: branch-<name> + sha.
           # Dispatch from main or a non-semver tag: sha only.
+          # Branch tags use prefix=branch- so a branch named latest/v0.1 cannot overwrite production aliases.
           prod=false
           branch_tag=false
           major_alias=false
@@ -116,6 +129,10 @@ jobs:
         with:
           # https://github.com/docker/metadata-action#images-input
           images: ghcr.io/${{ env.IMAGE_NAME }}
+          # Disable auto-latest so latest can only come from the explicit raw tag below.
+          # https://github.com/docker/metadata-action#flavor-input
+          flavor: |
+            latest=false
           # https://github.com/docker/metadata-action#latest-tag
           # https://github.com/docker/metadata-action#typesha
           # https://github.com/docker/metadata-action#typeref
@@ -125,7 +142,7 @@ jobs:
             type=semver,pattern={{version}},value=${{ github.ref_name }},enable=${{ steps.flavor.outputs.IS_PRODUCTION == 'true' }}
             type=semver,pattern=v{{major}}.{{minor}},value=${{ github.ref_name }},enable=${{ steps.flavor.outputs.IS_PRODUCTION == 'true' }}
             type=semver,pattern=v{{major}},value=${{ github.ref_name }},enable=${{ steps.flavor.outputs.ENABLE_MAJOR_ALIAS == 'true' }}
-            type=ref,event=branch,enable=${{ steps.flavor.outputs.ENABLE_BRANCH_TAG == 'true' }}
+            type=ref,event=branch,prefix=branch-,enable=${{ steps.flavor.outputs.ENABLE_BRANCH_TAG == 'true' }}
             type=sha,prefix=sha-,format=short
           # https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
           labels: |
@@ -193,6 +210,11 @@ jobs:
             fi
           done <<< "${{ steps.metadata.outputs.tags }}"
           docker run --rm mkdocs-material:ci-smoke --version
+          # Entrypoint is mkdocs; --version reports the MkDocs CLI, not Material.
+          # Override entrypoint to confirm the requirements.txt pin is in the image.
+          docker run --rm --entrypoint pip mkdocs-material:ci-smoke show mkdocs-material
+          docker run --rm --entrypoint pip mkdocs-material:ci-smoke show mkdocs-material \
+            | grep -F "Version: ${MATERIAL_VERSION}"
 
       - name: Push the smoke-tested image
         if: github.repository == 'rwaight/rwaight.github.io' && github.actor != 'dependabot[bot]'

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # General
 .DS_Store
 
+# Agent git worktrees
+/.worktrees/
+
 # the '.venv' directory is used for python virtual environments
 .venv
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,3 +1,5 @@
+# Independently built from a public Python Alpine base and pinned PyPI packages.
+# Plugin versions are pinned in requirements.txt (not the repo-root mkdocs-requirements.txt).
 FROM python:3.12-alpine
 
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -6,6 +8,8 @@ WORKDIR /tmp
 
 COPY requirements.txt /tmp/requirements.txt
 
+# git + openssh: git-revision-date and git-committers plugins
+# tini: used as the image entrypoint
 RUN apk add --no-cache \
       git \
       git-fast-import \
@@ -17,9 +21,11 @@ RUN apk add --no-cache \
  && git config --system --add safe.directory /docs \
  && git config --system --add safe.directory /site
 
+# Set working directory
 WORKDIR /docs
 
 EXPOSE 8000
 
+## Start development server by default
 ENTRYPOINT ["/sbin/tini", "--", "mkdocs"]
 CMD ["serve", "--dev-addr=0.0.0.0:8000"]

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,33 +1,25 @@
-# pass 'VERSION_SOURCE' as a build argument to dynamically set the MkDocs version
-# https://docs.docker.com/build/building/variables/#arg-usage-example
-ARG VERSION_SOURCE=latest
+FROM python:3.12-alpine
 
-# https://hub.docker.com/r/squidfunk/mkdocs-material
-# https://github.com/squidfunk/mkdocs-material/pkgs/container/mkdocs-material
-#FROM ghcr.io/squidfunk/mkdocs-material:9.6.19
-FROM ghcr.io/squidfunk/mkdocs-material:$VERSION_SOURCE
-#FROM ghcr.io/squidfunk/mkdocs-material
-# https://hub.docker.com/r/squidfunk/mkdocs-material/tags
+ENV PYTHONDONTWRITEBYTECODE=1
 
-# https://docs.docker.com/reference/dockerfile/#understand-how-arg-and-from-interact
-# An ARG declared before a FROM is outside of a build stage, so it can't be used in any instruction after a FROM.
-# To use the default value of an ARG declared before the first FROM use an ARG instruction without a value inside of a build stage.
-ARG VERSION_SOURCE
-RUN echo $VERSION_SOURCE
+WORKDIR /tmp
 
-RUN pip install mkdocs-awesome-nav
-RUN pip install mkdocs-macros-plugin
-RUN pip install mkdocs-git-revision-date-localized-plugin
-RUN pip install mkdocs-git-committers-plugin-2
+COPY requirements.txt /tmp/requirements.txt
 
-LABEL name="mkdocs-material"
-LABEL source_version="$VERSION_SOURCE"
-LABEL repository="https://github.com/rwaight/rwaight.github.io"
-LABEL homepage="https://github.com/rwaight/rwaight.github.io"
+RUN apk add --no-cache \
+      git \
+      git-fast-import \
+      openssh \
+      tini \
+ && pip install --no-cache-dir --upgrade pip \
+ && pip install --no-cache-dir -r /tmp/requirements.txt \
+ && rm -rf /tmp/* /root/.cache \
+ && git config --system --add safe.directory /docs \
+ && git config --system --add safe.directory /site
 
-# Set working directory
 WORKDIR /docs
 
-## Start development server by default
+EXPOSE 8000
+
 ENTRYPOINT ["/sbin/tini", "--", "mkdocs"]
 CMD ["serve", "--dev-addr=0.0.0.0:8000"]

--- a/container/README.md
+++ b/container/README.md
@@ -22,7 +22,7 @@ Git tags in this repository look like `v0.1.13`. Those git tags are not also pub
 | --- | --- |
 | Production git tag `v0.x.y` (push or manual dispatch) | `0.x.y`, `v0.x`, `latest`, `sha-<short>` |
 | Production git tag `v1.x.y` or later | `X.Y.Z`, `vX.Y`, `vX`, `latest`, `sha-<short>` |
-| Feature branch (path-filtered) | sanitized branch name, `sha-<short>` |
+| Feature branch (path-filtered) | `branch-<sanitized-name>`, `sha-<short>` |
 | Manual dispatch from `main` | `sha-<short>` only |
 
 While the image is in the `0.x` series, a moving `v0` tag is **not** published.

--- a/container/README.md
+++ b/container/README.md
@@ -6,9 +6,11 @@ This image is built in this repository from a public Python Alpine base and pinn
 
 Plugin versions for the image are pinned in [`requirements.txt`](requirements.txt). The root `mkdocs-requirements.txt` file is a separate local lockfile and is not used by this image or by the GitHub Pages deploy workflow.
 
+The image is **linux/amd64** only. On Apple Silicon, Docker Desktop will emulate it.
+
 ## Pull
 
-The package is public. After a production publish, pull without logging in to GHCR:
+After a production `vX.Y.Z` git tag, GHCR publishes `latest`. A new package can start **private** even from a public repository; set `ghcr.io/rwaight/rwaight.github.io/mkdocs-material` to Public in GitHub Packages once, then pull without logging in:
 
 ```shell
 docker pull ghcr.io/rwaight/rwaight.github.io/mkdocs-material:latest
@@ -16,7 +18,7 @@ docker pull ghcr.io/rwaight/rwaight.github.io/mkdocs-material:latest
 
 ## Tags
 
-Git tags in this repository look like `v0.1.13`. Those git tags are not also published as GHCR tags.
+Git tags in this repository look like `v0.1.13`. The literal `v`-prefixed patch tag (for example `v0.1.13`) is not also a GHCR tag.
 
 | Event | GHCR tags |
 | --- | --- |
@@ -34,10 +36,10 @@ Feature-branch and other test images never receive `latest` or production semver
 From the repository root:
 
 ```shell
-docker run --rm -it -p 8000:8000 -v ${PWD}:/docs ghcr.io/rwaight/rwaight.github.io/mkdocs-material:latest
+docker run --rm -it -p 8000:8000 -e ENABLE_GIT_COMMITTERS=false -v ${PWD}:/docs ghcr.io/rwaight/rwaight.github.io/mkdocs-material:latest
 ```
 
-Then open [http://localhost:8000](http://localhost:8000).
+Then open [http://localhost:8000](http://localhost:8000). `ENABLE_GIT_COMMITTERS=false` skips unauthenticated GitHub API calls from the git-committers plugin during local preview.
 
 ## Included packages
 

--- a/container/README.md
+++ b/container/README.md
@@ -2,7 +2,7 @@
 
 Public image: `ghcr.io/rwaight/rwaight.github.io/mkdocs-material`
 
-This image is built in this repository from a public Python Alpine base and pinned PyPI packages. It is intended for **local preview** of this site. The MkDocs development server is not suitable for production deployment.
+This image is built in this repository from a public Python Alpine base and pinned PyPI packages. It does not wrap the upstream `squidfunk/mkdocs-material` image. It is intended for **local preview** of this site. The MkDocs development server is not suitable for production deployment.
 
 Plugin versions for the image are pinned in [`requirements.txt`](requirements.txt). The root `mkdocs-requirements.txt` file is a separate local lockfile and is not used by this image or by the GitHub Pages deploy workflow.
 

--- a/container/README.md
+++ b/container/README.md
@@ -1,4 +1,50 @@
 # Material for MkDocs Container
 
-The **Material for MkDocs Container** image is built from the [`squidfunk/mkdocs-material` container](https://github.com/squidfunk/mkdocs-material/pkgs/container/mkdocs-material).
+Public image: `ghcr.io/rwaight/rwaight.github.io/mkdocs-material`
 
+This image is built in this repository from a public Python Alpine base and pinned PyPI packages. It is intended for **local preview** of this site. The MkDocs development server is not suitable for production deployment.
+
+Plugin versions for the image are pinned in [`requirements.txt`](requirements.txt). The root `mkdocs-requirements.txt` file is a separate local lockfile and is not used by this image or by the GitHub Pages deploy workflow.
+
+## Pull
+
+The package is public. After a production publish, pull without logging in to GHCR:
+
+```shell
+docker pull ghcr.io/rwaight/rwaight.github.io/mkdocs-material:latest
+```
+
+## Tags
+
+Git tags in this repository look like `v0.1.13`. Those git tags are not also published as GHCR tags.
+
+| Event | GHCR tags |
+| --- | --- |
+| Production git tag `v0.x.y` (push or manual dispatch) | `0.x.y`, `v0.x`, `latest`, `sha-<short>` |
+| Production git tag `v1.x.y` or later | `X.Y.Z`, `vX.Y`, `vX`, `latest`, `sha-<short>` |
+| Feature branch (path-filtered) | sanitized branch name, `sha-<short>` |
+| Manual dispatch from `main` | `sha-<short>` only |
+
+While the image is in the `0.x` series, a moving `v0` tag is **not** published.
+
+Feature-branch and other test images never receive `latest` or production semver aliases.
+
+## Run (local preview)
+
+From the repository root:
+
+```shell
+docker run --rm -it -p 8000:8000 -v ${PWD}:/docs ghcr.io/rwaight/rwaight.github.io/mkdocs-material:latest
+```
+
+Then open [http://localhost:8000](http://localhost:8000).
+
+## Included packages
+
+Pinned in `requirements.txt`:
+
+- mkdocs-material 9.7.7
+- mkdocs-awesome-nav
+- mkdocs-macros-plugin
+- mkdocs-git-revision-date-localized-plugin
+- mkdocs-git-committers-plugin-2

--- a/container/requirements.txt
+++ b/container/requirements.txt
@@ -1,0 +1,5 @@
+mkdocs-material==9.7.7
+mkdocs-awesome-nav==3.1.2
+mkdocs-macros-plugin==1.3.7
+mkdocs-git-revision-date-localized-plugin==1.4.7
+mkdocs-git-committers-plugin-2==2.5.0

--- a/container/requirements.txt
+++ b/container/requirements.txt
@@ -1,3 +1,6 @@
+# Pinned packages for the image built from container/Dockerfile.
+# Site deploy in .github/workflows/publish-pages.yml uses a separate pip install
+# and does not consume this file.
 mkdocs-material==9.7.7
 mkdocs-awesome-nav==3.1.2
 mkdocs-macros-plugin==1.3.7

--- a/docs/guides/mkdocs/mkdocs-local-install.md
+++ b/docs/guides/mkdocs/mkdocs-local-install.md
@@ -33,7 +33,7 @@ In order to [preview MkDocs as you write](mkdocs-local-preview.md#previewing-as-
  --->
 
 
-This repository publishes a public image that already includes the plugins used by the site. Pull it without logging in to GHCR:
+This repository publishes an image that already includes the plugins used by the site. After a production tag, and after the GHCR package is set to Public, pull without logging in:
 
 === "Latest"
 

--- a/docs/guides/mkdocs/mkdocs-local-install.md
+++ b/docs/guides/mkdocs/mkdocs-local-install.md
@@ -3,7 +3,7 @@ title: Local installation
 description: Local installation of MkDocs
 date:
   created: 2024-05-28
-  updated: 2025-05-08
+  updated: 2026-08-19
 authors: [rwaight]
 categories:
   - MkDocs
@@ -22,44 +22,33 @@ In order to [preview MkDocs as you write](mkdocs-local-preview.md#previewing-as-
 
     The Docker container is intended for [local previewing purposes only and is **not suitable for deployment**](https://squidfunk.github.io/mkdocs-material/getting-started/#with-docker){:target="_blank"}. This is because the web server used by MkDocs for live previews is not designed for production use and may have security vulnerabilities.
 
-<!--- The Docker container warning is from:
- https://squidfunk.github.io/mkdocs-material/getting-started/#with-docker
- --->
-
 ## Install with docker
 
-<!--- The content from this section is directly from 
- https://raw.githubusercontent.com/squidfunk/mkdocs-material/master/docs/getting-started.md
- --->
-
-The official [Docker image] is a great way to get up and running in a few
-minutes, as it comes with all dependencies pre-installed. Open up a terminal
-and pull the image with:
+This repository publishes a public image that already includes the plugins used by the site. Pull it without logging in to GHCR:
 
 === "Latest"
 
     ```shell
-    docker pull squidfunk/mkdocs-material
+    docker pull ghcr.io/rwaight/rwaight.github.io/mkdocs-material:latest
     ```
 
-=== "9.x"
+=== "0.x"
 
     ```shell
-    docker pull squidfunk/mkdocs-material:9
+    docker pull ghcr.io/rwaight/rwaight.github.io/mkdocs-material:v0.1
     ```
 
-The `mkdocs` executable is provided as an entry point and `serve` is the
-default command. If you're not familiar with Docker don't worry, we have you
-covered in the following sections.
+The `mkdocs` executable is the entrypoint and `serve` is the default command. See the [container README](https://github.com/rwaight/rwaight.github.io/blob/main/container/README.md) for the full tag policy. While the image is in the `0.x` series, there is no moving `v0` tag.
 
-The following plugins are bundled with the Docker image:
+The image includes:
 
-- [mkdocs-minify-plugin]
-- [mkdocs-redirects]
+- mkdocs-material
+- mkdocs-awesome-nav
+- mkdocs-macros-plugin
+- mkdocs-git-revision-date-localized-plugin
+- mkdocs-git-committers-plugin-2
 
-  [Docker image]: https://hub.docker.com/r/squidfunk/mkdocs-material/
-  [mkdocs-minify-plugin]: https://github.com/byrnereese/mkdocs-minify-plugin
-  [mkdocs-redirects]: https://github.com/datarobot/mkdocs-redirects
+  [Docker image]: https://github.com/rwaight/rwaight.github.io/pkgs/container/rwaight.github.io%2Fmkdocs-material
 
 ???+ warning
 
@@ -68,97 +57,21 @@ The following plugins are bundled with the Docker image:
     MkDocs for live previews is not designed for production use and may have
     security vulnerabilities.
 
-???+ question "How to add plugins to the Docker image?"
-
-    Material for MkDocs only bundles selected plugins in order to keep the size
-    of the official image small. If the plugin you want to use is not included,
-    you can add them easily following the [add plugins to the Docker image](#add-plugins-to-the-docker-image) section below.
-
 ### Verify required plugins
 
-Be sure to include the plugins that are installed in the 'publish-pages' 
-workflow. Look in the repos `.github/workflows/publish-pages.yml` file
-for commands starting with `pip install` for needed MkDocs plugins.
+The published image is pinned in [`container/requirements.txt`](https://github.com/rwaight/rwaight.github.io/blob/main/container/requirements.txt). Site deploy in `.github/workflows/publish-pages.yml` still installs packages with `pip` and does not use this image.
 
 ### Add plugins to the image
 
-Material for MkDocs only bundles selected plugins in order to keep the size
-of the official image small. If the plugin you want to use is not included,
-you can add them easily:
+If you need extra plugins beyond what this repository publishes, extend the public image:
 
-=== "Material for MkDocs"
-
-    Create a `Dockerfile` and extend the official image:
-
-    ```Dockerfile title="Dockerfile"
-    FROM squidfunk/mkdocs-material
-    RUN pip install mkdocs-awesome-nav
-    RUN pip install mkdocs-macros-plugin
-    RUN pip install mkdocs-git-revision-date-localized-plugin
-    RUN pip install mkdocs-git-committers-plugin-2
-    ```
-
-=== "Insiders"
-
-    Clone or fork the Insiders repository, and create a file called
-    `user-requirements.txt` in the root of the repository. Then, add the
-    plugins that should be installed to the file, e.g.:
-
-    ``` txt title="user-requirements.txt"
-    mkdocs-awesome-nav
-    mkdocs-macros-plugin
-    mkdocs-git-revision-date-localized-plugin
-    mkdocs-git-committers-plugin-2
-    ```
-
-!!! tip "Verify correct list of plugins"
-
-    Be sure to include the plugins that are installed in the 'publish-pages' 
-    workflow. Look in the repos `.github/workflows/publish-pages.yml` file
-    for commands starting with `pip install` for needed MkDocs plugins.
-
-### Build the Docker image
-
-Next, build the image with the following command:
-
-```shell
-docker build -t squidfunk/mkdocs-material .
+```Dockerfile title="Dockerfile"
+{% include 'docker/mkdocs/Dockerfile' %}
+RUN pip install mkdocs-glightbox
 ```
 
-The new image will have additional packages installed and can be used
-exactly like the official image.
+### Build an extended image
 
-
-
-<!--- 
-    === "Material for MkDocs"
-
-  --- the below code block is from the MkDocs guide ---
-  --- 
-        ``` Dockerfile title="Dockerfile"
-        FROM squidfunk/mkdocs-material
-        RUN pip install mkdocs-macros-plugin
-        RUN pip install mkdocs-glightbox
-        ```
- ---
-  --- the below code block is from this repo ---
-  --- the below 'include' code block is from this repo ---
-  ---         
-        ```Dockerfile title="Dockerfile"
-        {% include 'docker/mkdocs/Dockerfile' %}
-        ```
- ---
-  --- the below code block is from this repo ---
-  ---         
-        ```Dockerfile title="Dockerfile"
-        FROM squidfunk/mkdocs-material
-        # be sure to include the plugins that are installed in the 'publish-pages' workflow
-        #     check the '.github/workflows/publish-pages.yml' file
-        RUN pip install mkdocs-awesome-nav
-        RUN pip install mkdocs-macros-plugin
-        RUN pip install mkdocs-git-revision-date-localized-plugin
-        RUN pip install mkdocs-git-committers-plugin-2
-        ```
- ---        
- --->
-
+```shell
+docker build -t mkdocs-material-local .
+```

--- a/docs/guides/mkdocs/mkdocs-local-install.md
+++ b/docs/guides/mkdocs/mkdocs-local-install.md
@@ -28,9 +28,8 @@ In order to [preview MkDocs as you write](mkdocs-local-preview.md#previewing-as-
 
 ## Install with docker
 
-<!--- This section was originally adapted from
+<!--- The content from this section is directly from 
  https://raw.githubusercontent.com/squidfunk/mkdocs-material/master/docs/getting-started.md
- and now documents this repository's published image.
  --->
 
 
@@ -85,3 +84,37 @@ RUN pip install mkdocs-glightbox
 ```shell
 docker build -t mkdocs-material-local .
 ```
+
+
+
+<!--- 
+    === "Material for MkDocs"
+
+  --- the below code block is from the MkDocs guide ---
+  --- 
+        ``` Dockerfile title="Dockerfile"
+        FROM squidfunk/mkdocs-material
+        RUN pip install mkdocs-macros-plugin
+        RUN pip install mkdocs-glightbox
+        ```
+ ---
+  --- the below code block is from this repo ---
+  --- the below 'include' code block is from this repo ---
+  ---         
+        ```Dockerfile title="Dockerfile"
+        {% include 'docker/mkdocs/Dockerfile' %}
+        ```
+ ---
+  --- the below code block is from this repo ---
+  ---         
+        ```Dockerfile title="Dockerfile"
+        FROM ghcr.io/rwaight/rwaight.github.io/mkdocs-material
+        # be sure to include the plugins that are installed in the 'publish-pages' workflow
+        #     check the '.github/workflows/publish-pages.yml' file
+        RUN pip install mkdocs-awesome-nav
+        RUN pip install mkdocs-macros-plugin
+        RUN pip install mkdocs-git-revision-date-localized-plugin
+        RUN pip install mkdocs-git-committers-plugin-2
+        ```
+ ---        
+ --->

--- a/docs/guides/mkdocs/mkdocs-local-install.md
+++ b/docs/guides/mkdocs/mkdocs-local-install.md
@@ -22,7 +22,17 @@ In order to [preview MkDocs as you write](mkdocs-local-preview.md#previewing-as-
 
     The Docker container is intended for [local previewing purposes only and is **not suitable for deployment**](https://squidfunk.github.io/mkdocs-material/getting-started/#with-docker){:target="_blank"}. This is because the web server used by MkDocs for live previews is not designed for production use and may have security vulnerabilities.
 
+<!--- The Docker container warning is from:
+ https://squidfunk.github.io/mkdocs-material/getting-started/#with-docker
+ --->
+
 ## Install with docker
+
+<!--- This section was originally adapted from
+ https://raw.githubusercontent.com/squidfunk/mkdocs-material/master/docs/getting-started.md
+ and now documents this repository's published image.
+ --->
+
 
 This repository publishes a public image that already includes the plugins used by the site. Pull it without logging in to GHCR:
 

--- a/docs/guides/mkdocs/mkdocs-local-preview.md
+++ b/docs/guides/mkdocs/mkdocs-local-preview.md
@@ -41,13 +41,13 @@ the `--detach` (`-d`) flag, but it is included below --->
 === "Unix, Powershell"
 
     ```shell
-    docker run --rm -d -it -p 8000:8000 -v ${PWD}:/docs ghcr.io/rwaight/rwaight.github.io/mkdocs-material:latest
+    docker run --rm -d -it -p 8000:8000 -e ENABLE_GIT_COMMITTERS=false -v ${PWD}:/docs ghcr.io/rwaight/rwaight.github.io/mkdocs-material:latest
     ```
 
 === "Windows"
 
     ```shell
-    docker run --rm -d -it -p 8000:8000 -v "%cd%":/docs ghcr.io/rwaight/rwaight.github.io/mkdocs-material:latest
+    docker run --rm -d -it -p 8000:8000 -e ENABLE_GIT_COMMITTERS=false -v "%cd%":/docs ghcr.io/rwaight/rwaight.github.io/mkdocs-material:latest
     ```
 
 Point your browser to [localhost:8000][live preview] and you should see:

--- a/docs/guides/mkdocs/mkdocs-local-preview.md
+++ b/docs/guides/mkdocs/mkdocs-local-preview.md
@@ -3,7 +3,7 @@ title: Previewing as you write
 description: How to preview MkDocs as you write
 date:
   created: 2025-05-06
-  updated: 2025-05-08
+  updated: 2026-08-19
 authors: [rwaight]
 categories:
   - MkDocs
@@ -41,13 +41,13 @@ the `--detach` (`-d`) flag, but it is included below --->
 === "Unix, Powershell"
 
     ```shell
-    docker run --rm -d -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
+    docker run --rm -d -it -p 8000:8000 -v ${PWD}:/docs ghcr.io/rwaight/rwaight.github.io/mkdocs-material:latest
     ```
 
 === "Windows"
 
     ```shell
-    docker run --rm -d -it -p 8000:8000 -v "%cd%":/docs squidfunk/mkdocs-material
+    docker run --rm -d -it -p 8000:8000 -v "%cd%":/docs ghcr.io/rwaight/rwaight.github.io/mkdocs-material:latest
     ```
 
 Point your browser to [localhost:8000][live preview] and you should see:

--- a/includes/docker/mkdocs/Dockerfile
+++ b/includes/docker/mkdocs/Dockerfile
@@ -1,1 +1,6 @@
+# https://github.com/rwaight/rwaight.github.io/pkgs/container/rwaight.github.io%2Fmkdocs-material
 FROM ghcr.io/rwaight/rwaight.github.io/mkdocs-material
+# Plugins used by this site are already in the published image (container/requirements.txt).
+# Site deploy in .github/workflows/publish-pages.yml still pip-installs and does not use this image.
+# Add extra plugins below, for example:
+# RUN pip install mkdocs-glightbox

--- a/includes/docker/mkdocs/Dockerfile
+++ b/includes/docker/mkdocs/Dockerfile
@@ -1,8 +1,1 @@
-# https://squidfunk.github.io/mkdocs-material/getting-started/#with-docker
-FROM squidfunk/mkdocs-material
-# be sure to include the plugins that are installed in the 'publish-pages' workflow
-#     check the '.github/workflows/publish-pages.yml' file
-RUN pip install mkdocs-awesome-nav
-RUN pip install mkdocs-macros-plugin
-RUN pip install mkdocs-git-revision-date-localized-plugin
-RUN pip install mkdocs-git-committers-plugin-2
+FROM ghcr.io/rwaight/rwaight.github.io/mkdocs-material

--- a/includes/docker/mkdocs/Dockerfile
+++ b/includes/docker/mkdocs/Dockerfile
@@ -1,6 +1,6 @@
-# https://github.com/rwaight/rwaight.github.io/pkgs/container/rwaight.github.io%2Fmkdocs-material
+# https://squidfunk.github.io/mkdocs-material/getting-started/#with-docker
 FROM ghcr.io/rwaight/rwaight.github.io/mkdocs-material
+# be sure to include the plugins that are installed in the 'publish-pages' workflow
+#     check the '.github/workflows/publish-pages.yml' file
 # Plugins used by this site are already in the published image (container/requirements.txt).
 # Site deploy in .github/workflows/publish-pages.yml still pip-installs and does not use this image.
-# Add extra plugins below, for example:
-# RUN pip install mkdocs-glightbox


### PR DESCRIPTION
# rwaight.github.io - Pull Request

## Why are you opening this PR?

Upstream Material for MkDocs is maintenance-only (EOL 5 Nov 2026). This repo currently wraps that image and never applies `latest` on a production git tag. This change builds a public image in this repository from a Python Alpine base and pinned PyPI packages, and publishes production GHCR tags only from semver git tags (`vX.Y.Z`).

Git tags stay `vX.Y.Z`. That string is not also a GHCR alias. While the image is in `0.x`, a moving `v0` tag is not published. Feature-branch images get `branch-<name>` and `sha-<short>` only. Site deploy in `publish-pages.yml` is unchanged and still uses pip.

## Related issues
**Issue URL(s)**:
